### PR TITLE
changes without context

### DIFF
--- a/Asset/src/V1/Gapic/AssetServiceGapicClient.php
+++ b/Asset/src/V1/Gapic/AssetServiceGapicClient.php
@@ -172,15 +172,6 @@ class AssetServiceGapicClient
         return self::$projectFeedNameTemplate;
     }
 
-    private static function getProjectNameTemplate()
-    {
-        if (null == self::$projectNameTemplate) {
-            self::$projectNameTemplate = new PathTemplate('projects/{project}');
-        }
-
-        return self::$projectNameTemplate;
-    }
-
     private static function getPathTemplateMap()
     {
         if (null == self::$pathTemplateMap) {
@@ -189,7 +180,6 @@ class AssetServiceGapicClient
                 'folderFeed' => self::getFolderFeedNameTemplate(),
                 'organizationFeed' => self::getOrganizationFeedNameTemplate(),
                 'projectFeed' => self::getProjectFeedNameTemplate(),
-                'project' => self::getProjectNameTemplate(),
             ];
         }
 
@@ -265,21 +255,6 @@ class AssetServiceGapicClient
     }
 
     /**
-     * Formats a string containing the fully-qualified path to represent
-     * a project resource.
-     *
-     * @param string $project
-     *
-     * @return string The formatted project resource.
-     */
-    public static function projectName($project)
-    {
-        return self::getProjectNameTemplate()->render([
-            'project' => $project,
-        ]);
-    }
-
-    /**
      * Parses a formatted name string and returns an associative array of the components in the name.
      * The following name formats are supported:
      * Template: Pattern
@@ -287,7 +262,6 @@ class AssetServiceGapicClient
      * - folderFeed: folders/{folder}/feeds/{feed}
      * - organizationFeed: organizations/{organization}/feeds/{feed}
      * - projectFeed: projects/{project}/feeds/{feed}.
-     * - project: projects/{project}.
      *
      * The optional $template argument can be supplied to specify a particular pattern, and must
      * match one of the templates listed above. If no $template argument is provided, or if the
@@ -609,14 +583,6 @@ class AssetServiceGapicClient
      * @param string $parent       Required. The relative name of the root asset. It can only be an
      *                             organization number (such as "organizations/123"), a project ID (such as
      *                             "projects/my-project-id")", or a project number (such as "projects/12345").
-     * @param int        $contentType    Optional. The content type.
-     *                                   For allowed values, use constants defined on {@see \Google\Cloud\Asset\V1\ContentType}
-     * @param TimeWindow $readTimeWindow Optional. The time window for the asset history. Both start_time and
-     *                                   end_time are optional and if set, it must be after the current time minus
-     *                                   35 days. If end_time is not set, it is default to current timestamp.
-     *                                   If start_time is not set, the snapshot of the assets at end_time will be
-     *                                   returned. The returned results contain all temporal assets whose time
-     *                                   window overlap with read_time_window.
      * @param array  $optionalArgs {
      *                             Optional.
      *
@@ -629,6 +595,16 @@ class AssetServiceGapicClient
      *
      *          The request becomes a no-op if the asset name list is empty, and the max
      *          size of the asset name list is 100 in one request.
+     *     @type int $contentType
+     *          Optional. The content type.
+     *          For allowed values, use constants defined on {@see \Google\Cloud\Asset\V1\ContentType}
+     *     @type TimeWindow $readTimeWindow
+     *          Optional. The time window for the asset history. Both start_time and
+     *          end_time are optional and if set, it must be after the current time minus
+     *          35 days. If end_time is not set, it is default to current timestamp.
+     *          If start_time is not set, the snapshot of the assets at end_time will be
+     *          returned. The returned results contain all temporal assets whose time
+     *          window overlap with read_time_window.
      *     @type RetrySettings|array $retrySettings
      *          Retry settings to use for this call. Can be a
      *          {@see Google\ApiCore\RetrySettings} object, or an associative array
@@ -640,14 +616,18 @@ class AssetServiceGapicClient
      *
      * @throws ApiException if the remote call fails
      */
-    public function batchGetAssetsHistory($parent, $contentType, $readTimeWindow, array $optionalArgs = [])
+    public function batchGetAssetsHistory($parent, array $optionalArgs = [])
     {
         $request = new BatchGetAssetsHistoryRequest();
         $request->setParent($parent);
-        $request->setContentType($contentType);
-        $request->setReadTimeWindow($readTimeWindow);
         if (isset($optionalArgs['assetNames'])) {
             $request->setAssetNames($optionalArgs['assetNames']);
+        }
+        if (isset($optionalArgs['contentType'])) {
+            $request->setContentType($optionalArgs['contentType']);
+        }
+        if (isset($optionalArgs['readTimeWindow'])) {
+            $request->setReadTimeWindow($optionalArgs['readTimeWindow']);
         }
 
         $requestParams = new RequestParamsHeaderDescriptor([

--- a/Asset/src/V1beta1/Gapic/AssetServiceGapicClient.php
+++ b/Asset/src/V1beta1/Gapic/AssetServiceGapicClient.php
@@ -31,7 +31,6 @@ use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
 use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\OperationResponse;
-use Google\ApiCore\PathTemplate;
 use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
@@ -123,8 +122,6 @@ class AssetServiceGapicClient
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];
-    private static $projectNameTemplate;
-    private static $pathTemplateMap;
 
     private $operationsClient;
 
@@ -145,83 +142,6 @@ class AssetServiceGapicClient
                 ],
             ],
         ];
-    }
-
-    private static function getProjectNameTemplate()
-    {
-        if (null == self::$projectNameTemplate) {
-            self::$projectNameTemplate = new PathTemplate('projects/{project}');
-        }
-
-        return self::$projectNameTemplate;
-    }
-
-    private static function getPathTemplateMap()
-    {
-        if (null == self::$pathTemplateMap) {
-            self::$pathTemplateMap = [
-                'project' => self::getProjectNameTemplate(),
-            ];
-        }
-
-        return self::$pathTemplateMap;
-    }
-
-    /**
-     * Formats a string containing the fully-qualified path to represent
-     * a project resource.
-     *
-     * @param string $project
-     *
-     * @return string The formatted project resource.
-     * @experimental
-     */
-    public static function projectName($project)
-    {
-        return self::getProjectNameTemplate()->render([
-            'project' => $project,
-        ]);
-    }
-
-    /**
-     * Parses a formatted name string and returns an associative array of the components in the name.
-     * The following name formats are supported:
-     * Template: Pattern
-     * - project: projects/{project}.
-     *
-     * The optional $template argument can be supplied to specify a particular pattern, and must
-     * match one of the templates listed above. If no $template argument is provided, or if the
-     * $template argument does not match one of the templates listed, then parseName will check
-     * each of the supported templates, and return the first match.
-     *
-     * @param string $formattedName The formatted name string
-     * @param string $template      Optional name of template to match
-     *
-     * @return array An associative array from name component IDs to component values.
-     *
-     * @throws ValidationException If $formattedName could not be matched.
-     * @experimental
-     */
-    public static function parseName($formattedName, $template = null)
-    {
-        $templateMap = self::getPathTemplateMap();
-
-        if ($template) {
-            if (!isset($templateMap[$template])) {
-                throw new ValidationException("Template name $template does not exist");
-            }
-
-            return $templateMap[$template]->match($formattedName);
-        }
-
-        foreach ($templateMap as $templateName => $pathTemplate) {
-            try {
-                return $pathTemplate->match($formattedName);
-            } catch (ValidationException $ex) {
-                // Swallow the exception to continue trying other path templates
-            }
-        }
-        throw new ValidationException("Input did not match any known format. Input: $formattedName");
     }
 
     /**

--- a/Asset/synth.metadata
+++ b/Asset/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": ".",
         "remote": "https://github.com/googleapis/google-cloud-php.git",
-        "sha": "ced6509282e5997fa3db5e6a1f1b0e54cdefe1d1"
+        "sha": "c75967261ddcf096a938643b7154325e4bf805dc"
       }
     },
     {

--- a/Asset/tests/Unit/V1/AssetServiceClientTest.php
+++ b/Asset/tests/Unit/V1/AssetServiceClientTest.php
@@ -22,14 +22,13 @@
 
 namespace Google\Cloud\Asset\Tests\Unit\V1;
 
+use Google\Cloud\Asset\V1\AssetServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
-use Google\Cloud\Asset\V1\AssetServiceClient;
 use Google\Cloud\Asset\V1\BatchGetAssetsHistoryResponse;
-use Google\Cloud\Asset\V1\ContentType;
 use Google\Cloud\Asset\V1\ExportAssetsResponse;
 use Google\Cloud\Asset\V1\Feed;
 use Google\Cloud\Asset\V1\IamPolicySearchResult;
@@ -38,7 +37,6 @@ use Google\Cloud\Asset\V1\OutputConfig;
 use Google\Cloud\Asset\V1\ResourceSearchResult;
 use Google\Cloud\Asset\V1\SearchAllIamPoliciesResponse;
 use Google\Cloud\Asset\V1\SearchAllResourcesResponse;
-use Google\Cloud\Asset\V1\TimeWindow;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
 use Google\Protobuf\Any;
@@ -314,10 +312,8 @@ class AssetServiceClientTest extends GeneratedTest
 
         // Mock request
         $parent = 'parent-995424086';
-        $contentType = ContentType::CONTENT_TYPE_UNSPECIFIED;
-        $readTimeWindow = new TimeWindow();
 
-        $response = $client->batchGetAssetsHistory($parent, $contentType, $readTimeWindow);
+        $response = $client->batchGetAssetsHistory($parent);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -356,11 +352,9 @@ class AssetServiceClientTest extends GeneratedTest
 
         // Mock request
         $parent = 'parent-995424086';
-        $contentType = ContentType::CONTENT_TYPE_UNSPECIFIED;
-        $readTimeWindow = new TimeWindow();
 
         try {
-            $client->batchGetAssetsHistory($parent, $contentType, $readTimeWindow);
+            $client->batchGetAssetsHistory($parent);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {


### PR DESCRIPTION
        autosynth cannot find the source of changes triggered by earlier changes in this
        repository, or by version upgrades to tools such as linters.